### PR TITLE
fix: pass MIME type when uploading documents to Papra

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -242,7 +242,7 @@ async function migrateOneDocument(doc, index, total, ctx) {
 	const { buffer, fileName: responseFileName } = await downloadDocument(ctx.paperlessUrl, ctx.paperlessToken, doc.id);
 	const ext = doc.mime_type ? MIME_EXTENSIONS[doc.mime_type] ?? `.${doc.mime_type.split("/")[1]}` : "";
 	const fileName = doc.original_file_name ?? responseFileName ?? `${doc.title}${ext}`;
-	const file = new File([buffer], fileName);
+	const file = new File([buffer], fileName, { type: doc.mime_type ?? "application/octet-stream" });
 	let documentId;
 	try {
 		const { document } = await ctx.client.forOrganization(ctx.orgId).uploadDocument({ file });

--- a/src/papra.ts
+++ b/src/papra.ts
@@ -103,7 +103,7 @@ async function migrateOneDocument(
   const { buffer, fileName: responseFileName } = await downloadDocument(ctx.paperlessUrl, ctx.paperlessToken, doc.id)
   const ext = doc.mime_type ? (MIME_EXTENSIONS[doc.mime_type] ?? `.${doc.mime_type.split('/')[1]}`) : ''
   const fileName = doc.original_file_name ?? responseFileName ?? `${doc.title}${ext}`
-  const file = new File([buffer], fileName)
+  const file = new File([buffer], fileName, { type: doc.mime_type ?? 'application/octet-stream' })
 
   // Upload to Papra
   let documentId: string


### PR DESCRIPTION
## Summary
- Fixes missing MIME type on `File` object when uploading to Papra
- Without it, Papra treated all files as binary → no previews, no OCR

Closes #13

## Test plan
- [ ] Run migration, verify PDF previews render in Papra
- [ ] Verify OCR content is extracted on migrated documents