### PR TITLE
fix: use HTTP Content-Type as MIME fallback when doc.mime_type is null

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,48 @@
-# Development Notes
+# CLAUDE.md
 
-Run `pnpm run build` and commit `dist/` whenever you change the source code before pushing. The built `dist/` is committed to the repo because `npm install -g github:...` is broken on npm 11 and doesn't run build steps reliably.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Development
+
+> Package manager is `pnpm`, but `npm run` works for all scripts.
+
+```bash
+npm run build          # compile src/ → dist/ via tsdown
+npm run dev            # run CLI directly via tsx (no build needed)
+npm test               # run tests once
+npm run test:watch     # watch mode
+npm run typecheck      # tsc --noEmit
+npm run lint           # eslint
+npm run lint:fix       # eslint --fix
+```
+
+Run a single test file:
+```bash
+npx vitest run src/mapping.test.ts
+```
+
+**Always run `npm run build` and commit `dist/` after changing source.** The built `dist/` is committed to the repo because `npm install -g github:...` on npm 11 doesn't run build steps reliably.
+
+## Architecture
+
+Single-purpose CLI tool: reads all documents from a Paperless-ngx instance and imports them into Papra.
+
+**Data flow:**
+
+```
+cli.ts  →  paperless.ts (fetch/download)  →  mapping.ts (transform)  →  papra.ts (upload)
+```
+
+- **`paperless.ts`** — Paperless-ngx API client. Paginates all tags, correspondents, document types, and documents via `fetchAllPaginated`. Downloads original files via `downloadDocument`, which returns the file buffer, filename from `Content-Disposition`, and `Content-Type` header.
+- **`mapping.ts`** — Transforms Paperless entities into Papra-compatible shapes. Correspondents and document types become Papra tags with fixed colors (`correspondent:NAME`, `type:NAME`). Tag names are truncated to 50 chars. `encodeDocumentName` prefixes the title with `[YYYY-MM-DD]` and `[ASN:N]` if present.
+- **`papra.ts`** — Papra API client wrapper. `migrateOneDocument` downloads the file, builds a `File` object (using `doc.mime_type` → HTTP `Content-Type` → `application/octet-stream` as MIME fallback), uploads it, then PATCHes the name and OCR content in one call, and associates tags. Duplicate uploads (409) are silently skipped.
+- **`cli.ts`** — Three subcommands: `migrate` (full run), `dry-run` (preview only, no writes), `export-only` (dump Paperless data to JSON). All credentials can be passed as CLI flags or env vars (`PAPERLESS_URL`, `PAPERLESS_TOKEN`, `PAPRA_URL`, `PAPRA_TOKEN`, `PAPRA_ORG_ID`).
+
+**Papra API key** must have permissions: `organizations:read`, `documents:create`, `documents:read`, `documents:update`, `tags:create`, `tags:read` — validated on startup by `migrate`.
+
+`dry-run` is read-only (hits Paperless only, no writes to Papra) — safe for testing credentials and previewing tag mappings.
+
+**Key design decisions:**
+- Migration is idempotent: re-running skips already-uploaded documents (Papra returns 409 on duplicates).
+- Tags are created once up-front; existing tags with matching names are reused.
+- `resolveNextUrl` validates that pagination URLs stay on the same hostname to prevent SSRF.

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -160,7 +160,8 @@ async function downloadDocument(baseUrl, token, id) {
 	const fileName = rawName ? rawName.split(/[/\\]/).pop() ?? null : null;
 	return {
 		buffer: response._data,
-		fileName
+		fileName,
+		contentType: response.headers.get("content-type")
 	};
 }
 async function exportAll(baseUrl, token) {
@@ -239,10 +240,11 @@ async function patchDocument(ctx, docId, body) {
 async function migrateOneDocument(doc, index, total, ctx) {
 	const encodedName = encodeDocumentName(doc.title, doc.created_date, doc.archive_serial_number);
 	console.log(`${pc.dim(`[${index + 1}/${total}]`)} Migrating "${pc.bold(encodedName)}"...`);
-	const { buffer, fileName: responseFileName } = await downloadDocument(ctx.paperlessUrl, ctx.paperlessToken, doc.id);
+	const { buffer, fileName: responseFileName, contentType: responseContentType } = await downloadDocument(ctx.paperlessUrl, ctx.paperlessToken, doc.id);
+	const mimeType = doc.mime_type ?? responseContentType ?? "application/octet-stream";
 	const ext = doc.mime_type ? MIME_EXTENSIONS[doc.mime_type] ?? `.${doc.mime_type.split("/")[1]}` : "";
 	const fileName = doc.original_file_name ?? responseFileName ?? `${doc.title}${ext}`;
-	const file = new File([buffer], fileName, { type: doc.mime_type ?? "application/octet-stream" });
+	const file = new File([buffer], fileName, { type: mimeType });
 	let documentId;
 	try {
 		const { document } = await ctx.client.forOrganization(ctx.orgId).uploadDocument({ file });

--- a/src/paperless.ts
+++ b/src/paperless.ts
@@ -127,7 +127,7 @@ export async function downloadDocument(baseUrl: string, token: string, id: numbe
   const match = disposition?.match(/filename="?([^"]+)"?/)
   const rawName = utf8Match?.[1] ? decodeURIComponent(utf8Match[1]) : match?.[1] ?? null
   const fileName = rawName ? (rawName.split(/[/\\]/).pop() ?? null) : null
-  return { buffer: response._data as ArrayBuffer, fileName }
+  return { buffer: response._data as ArrayBuffer, fileName, contentType: response.headers.get('content-type') }
 }
 
 export async function exportAll(baseUrl: string, token: string): Promise<PaperlessExport> {

--- a/src/paperless.ts
+++ b/src/paperless.ts
@@ -116,7 +116,7 @@ export async function fetchDocuments(baseUrl: string, token: string): Promise<Pa
   return fetchAllPaginated(baseUrl, '/api/documents/', token, paperlessDocumentSchema)
 }
 
-export async function downloadDocument(baseUrl: string, token: string, id: number): Promise<{ buffer: ArrayBuffer, fileName: string | null }> {
+export async function downloadDocument(baseUrl: string, token: string, id: number): Promise<{ buffer: ArrayBuffer, fileName: string | null, contentType: string | null }> {
   const response = await ofetch.raw(`${baseUrl}/api/documents/${id}/download/?original=true`, {
     headers: createHeaders(token),
     responseType: 'arrayBuffer',

--- a/src/papra.test.ts
+++ b/src/papra.test.ts
@@ -54,6 +54,7 @@ function setupMocks() {
   vi.mocked(downloadDocument).mockResolvedValue({
     buffer: new ArrayBuffer(8),
     fileName: 'test.pdf',
+    contentType: 'application/pdf',
   })
 
   vi.mocked(ofetch).mockResolvedValue({}) // PATCH call

--- a/src/papra.ts
+++ b/src/papra.ts
@@ -100,10 +100,11 @@ async function migrateOneDocument(
   console.log(`${pc.dim(`[${index + 1}/${total}]`)} Migrating "${pc.bold(encodedName)}"...`)
 
   // Download from Paperless
-  const { buffer, fileName: responseFileName } = await downloadDocument(ctx.paperlessUrl, ctx.paperlessToken, doc.id)
+  const { buffer, fileName: responseFileName, contentType: responseContentType } = await downloadDocument(ctx.paperlessUrl, ctx.paperlessToken, doc.id)
+  const mimeType = doc.mime_type ?? responseContentType ?? 'application/octet-stream'
   const ext = doc.mime_type ? (MIME_EXTENSIONS[doc.mime_type] ?? `.${doc.mime_type.split('/')[1]}`) : ''
   const fileName = doc.original_file_name ?? responseFileName ?? `${doc.title}${ext}`
-  const file = new File([buffer], fileName, { type: doc.mime_type ?? 'application/octet-stream' })
+  const file = new File([buffer], fileName, { type: mimeType })
 
   // Upload to Papra
   let documentId: string


### PR DESCRIPTION
## Summary

- `downloadDocument` now returns the `Content-Type` response header alongside the buffer and filename
- `migrateOneDocument` uses it as a fallback when `doc.mime_type` is null, before dropping to `application/octet-stream`
- Without this, documents with a null `mime_type` would be uploaded as opaque binary blobs, causing Papra to skip OCR and previews — the same class of bug as #13

## Test plan

- [ ] Run `migrate` against a Paperless instance where some documents have `mime_type: null` and verify Papra shows previews and runs OCR
- [ ] Re-run migration to confirm idempotency (duplicates skipped)

🤖 Generated with [Claude Code](https://claude.ai/code)